### PR TITLE
hotfix: api

### DIFF
--- a/src/heimdallr/entrypoint/v1/assignments.py
+++ b/src/heimdallr/entrypoint/v1/assignments.py
@@ -102,7 +102,7 @@ async def get_assignment_by_id(
     Returns an assignment by ID.
     """
 
-    model: Assignment | None = await repository.find_by(id=assignment_id)  # type: ignore[func-returns-value]
+    model: Assignment | None = await repository.find_by(_id=str(assignment_id))  # type: ignore[func-returns-value]
 
     if not model:
         raise HTTPException(
@@ -110,6 +110,6 @@ async def get_assignment_by_id(
             detail=f"Assignment with id {assignment_id} not found.",
         )
 
-    event = AssignmentVerified(**model.dict())
+    event = AssignmentVerified(**model.model_dump())
 
     return ResponseModel(data=event)

--- a/src/heimdallr/service_layer/assignment_verifier.py
+++ b/src/heimdallr/service_layer/assignment_verifier.py
@@ -95,7 +95,7 @@ class SpacyAssignmentVerifier(AssignmentVerifier):
         comparisons: list[AssignmentCompared] = []
 
         # using concurrent.futures to parallelize the comparisons
-        with concurrent.futures.ProcessPoolExecutor() as executor:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = [executor.submit(self.compare_assignments, assignment, entry) for assignment in assignments]
 
             for future in concurrent.futures.as_completed(futures):


### PR DESCRIPTION
## Fixes

- Fixed wrong `MongoDB` filter. `id` is actually saved as `_id`.
- Fixed lock error. Replace `ProcessPoolExecutor` for `ThreadPoolExecutor`